### PR TITLE
Parallelization in query* calls and update to KDTree

### DIFF
--- a/entropy_estimators/continuous.py
+++ b/entropy_estimators/continuous.py
@@ -22,7 +22,7 @@
 import functools
 import numpy as np
 
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 from scipy.special import gamma, digamma
 from scipy.stats   import rankdata
 
@@ -211,7 +211,7 @@ def get_h(x, k=1, norm='max', min_dist=0.):
     else:
         raise NotImplementedError("Variable 'norm' either 'max' or 'euclidean'")
 
-    kdtree = cKDTree(x)
+    kdtree = KDTree(x)
 
     # query all points -- k+1 as query point also in initial set
     # distances, _ = kdtree.query(x, k + 1, eps=0, p=norm)
@@ -288,9 +288,9 @@ def get_mi(x, y, k=1, normalize=None, norm='max', estimator='ksg'):
 
         # store data pts in kd-trees for efficient nearest neighbour computations
         # TODO: choose a better leaf size
-        x_tree  = cKDTree(x)
-        y_tree  = cKDTree(y)
-        xy_tree = cKDTree(xy)
+        x_tree  = KDTree(x)
+        y_tree  = KDTree(y)
+        xy_tree = KDTree(xy)
 
         # kth nearest neighbour distances for every state
         if norm == 'max': # max norm:
@@ -386,10 +386,10 @@ def get_pmi(x, y, z, k=1, normalize=None, norm='max', estimator='fp'):
     elif estimator == 'fp':
 
         # construct k-d trees
-        z_tree   = cKDTree(z)
-        xz_tree  = cKDTree(xz)
-        yz_tree  = cKDTree(yz)
-        xyz_tree = cKDTree(xyz)
+        z_tree   = KDTree(z)
+        xz_tree  = KDTree(xz)
+        yz_tree  = KDTree(yz)
+        xyz_tree = KDTree(xyz)
 
         # kth nearest neighbour distances for every state
         if norm == 'max': # max norm:
@@ -421,8 +421,8 @@ def get_pmi(x, y, z, k=1, normalize=None, norm='max', estimator='fp'):
         # but the estimators is just crap.
 
         # construct k-d trees
-        xz_tree  = cKDTree(xz,  leafsize=2*k)
-        yz_tree  = cKDTree(yz,  leafsize=2*k)
+        xz_tree  = KDTree(xz,  leafsize=2*k)
+        yz_tree  = KDTree(yz,  leafsize=2*k)
 
         # determine k-nn distances
         n = len(x)
@@ -494,7 +494,7 @@ def get_imin(x1, x2, y, k=1, normalize=None, norm='max'):
     else:
         raise NotImplementedError("Variable 'norm' either 'max' or 'euclidean'")
 
-    y_tree  = cKDTree(y)
+    y_tree  = KDTree(y)
 
     n = len(y)
     i_spec = np.zeros((2, n))
@@ -509,8 +509,8 @@ def get_imin(x1, x2, y, k=1, normalize=None, norm='max'):
 
         # store data pts in kd-trees for efficient nearest neighbour computations
         # TODO: choose a better leaf size
-        x_tree  = cKDTree(x)
-        xy_tree = cKDTree(xy)
+        x_tree  = KDTree(x)
+        xy_tree = KDTree(xy)
 
         # kth nearest neighbour distances for every state
         # query with k=k+1 to return the nearest neighbour, not counting the data point itself


### PR DESCRIPTION
Hello, thanks for creating this package.

There have been updates in SciPy that allows for parallel processing in the various tree query calls used in this package that I have found to be quite beneficial. Additionally, SciPy seems to [prefer](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html) `KDTree` over `cKDTree` going forward.

I have changed to `KDTree` accordingly and added `workers` parameter (Default to 1 as in SciPy) that can be used to speed up entropy estimations. Tests still pass although there aren't much improvements in speed there. However, using `get_h` on my sample data the difference is significant. Done with 18 workers on an i9-10900K.

|Test|Single| Parallel (18 workers)|
|---|---|---|
|`test_get_h`|1.44 ms ± 59.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)|1.58 ms ± 8.87 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)|
|`test_get_h_1d`| 706 µs ± 5.58 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each) | 932 µs ± 3.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each) |
|`test_get_mi`| 358 ms ± 22.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)|366 ms ± 23.7 ms per loopget_h(): 1.44 ms ± 59.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each) |
|`test_get_pmi` |811 ms ± 27.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) |810 ms ± 72.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) |
My sample data:  float64 np.array with size (90000, 31)|  1min 55s ± 4.6 s per loop (mean ± std. dev. of 7 runs, 1 loop each)|17.9 s ± 157 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Hope this can be useful, and any feedback is welcome. Thanks!