### PR TITLE
Add base argument to entropy, MI and PMI estimators and simplify PMI calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+**.egg-info/
+**__pycache__/


### PR DESCRIPTION
#### Modifications
* add `base` argument to estimators to allow for entropy, MI and PMI measures to be in e.g., bits instead of nats
* simplify PMI MVN calculation by re-using estimates from entropy function
* tiny adjustments of documentation, e.g., `I(X,Y)` -> `I(X;Y)`
* add `.gitignore`

#### Comments
* The `base` argument is not strictly necessarily needed as
`get_mi_mvn(x, y) / np.log(2)` and `get_mi_mvn(x, y, base=2)` yield the same output in the end.
* I did not add the `base` argument to the Imin and PID estimators, yet. Is this mathematically correct to do so for these, too?